### PR TITLE
devfreq_boost: Mark boost kthreads as performance critical

### DIFF
--- a/drivers/devfreq/devfreq_boost.c
+++ b/drivers/devfreq/devfreq_boost.c
@@ -329,8 +329,8 @@ static int __init devfreq_boost_init(void)
 	for (i = 0; i < DEVFREQ_MAX; i++) {
 		struct boost_dev *b = d->devices + i;
 
-		thread[i] = kthread_run(devfreq_boost_thread, b,
-					"devfreq_boostd/%d", i);
+		thread[i] = kthread_run_perf_critical(cpu_perf_mask, devfreq_boost_thread, b,
+						      "devfreq_boostd/%d", i);
 		if (IS_ERR(thread[i])) {
 			ret = PTR_ERR(thread[i]);
 			pr_err("Failed to create kthread, err: %d\n", ret);


### PR DESCRIPTION
The boost kthreads are performance critical for obvious reasons.